### PR TITLE
 Check if whitelistIP is empty even if it contains whitespace only 

### DIFF
--- a/Controllers/Frontend/Profiler.php
+++ b/Controllers/Frontend/Profiler.php
@@ -23,7 +23,7 @@ class Shopware_Controllers_Frontend_Profiler extends Enlight_Controller_Action
         $this->cache = $this->get('frosh_profiler.cache');
         $config = $this->get('frosh_profiler.config');
 
-        if (!empty($config['whitelistIP'])) {
+        if (!empty(trim($config['whitelistIP']))) {
             $isIPWhitelisted = in_array($this->get('front')->Request()->getClientIp(), explode("\n", $config['whitelistIP']), false);
             if (!$isIPWhitelisted) {
                 throw new Enlight_Controller_Exception(

--- a/Subscriber/BlockAnnotation.php
+++ b/Subscriber/BlockAnnotation.php
@@ -51,7 +51,7 @@ class BlockAnnotation implements SubscriberInterface
         $this->pluginConfig = $pluginConfig;
 
         // Disable frontend blocks, if ip is not whitelisted
-        if (!empty($this->pluginConfig['whitelistIP']) && !in_array($front->Request()->getClientIp(), explode("\n", $this->pluginConfig['whitelistIP']))) {
+        if (!empty(trim($this->pluginConfig['whitelistIP'])) && !in_array($front->Request()->getClientIp(), explode("\n", $this->pluginConfig['whitelistIP']))) {
             $this->pluginConfig['frontendblocks'] = false;
         }
     }

--- a/Subscriber/Collector.php
+++ b/Subscriber/Collector.php
@@ -115,7 +115,7 @@ class Collector implements SubscriberInterface
 
         $isIPWhitelisted = in_array($this->container->get('front')->Request()->getClientIp(), explode("\n", $this->pluginConfig['whitelistIP']));
 
-        if (empty($this->pluginConfig['whitelistIP']) || $this->pluginConfig['whitelistIPProfile'] == 1 || $isIPWhitelisted) {
+        if (empty(trim($this->pluginConfig['whitelistIP'])) || $this->pluginConfig['whitelistIPProfile'] == 1 || $isIPWhitelisted) {
             $this->container->get('frosh_profiler.collector')->saveCollectInformation(
                 $this->profile->getId(),
                 $profileData,
@@ -123,7 +123,7 @@ class Collector implements SubscriberInterface
             );
         }
 
-        if ($this->profileController->Request()->getModuleName() == 'frontend' && (empty($this->pluginConfig['whitelistIP']) || $isIPWhitelisted)) {
+        if ($this->profileController->Request()->getModuleName() == 'frontend' && (empty(trim($this->pluginConfig['whitelistIP'])) || $isIPWhitelisted)) {
             $view = $this->container->get('template');
             $view->assign('sProfiler', $profileData);
             $view->assign('sProfilerCollectors', $this->container->get('frosh_profiler.collector')->getCollectors());


### PR DESCRIPTION
There was a problem that the toolbar was invisible when whitelistIP had a value of a multiple whitespace characters. It appeared to be empty but it was not :open_mouth: 