### PR TITLE
Added support for Dreischild Seo plugin

### DIFF
--- a/Components/BlockAnnotation/BlockAnnotator.php
+++ b/Components/BlockAnnotation/BlockAnnotator.php
@@ -54,7 +54,8 @@ class BlockAnnotator
                 strpos($block['name'], '/attributes') !== false ||
                 strpos($block['name'], '_attributes') !== false ||
                 strpos($block['name'], 'classes') !== false ||
-                strpos($block['name'], 'frontend_index_search_similar_results_') !== false) {
+                strpos($block['name'], 'frontend_index_search_similar_results_') !== false ||
+                (strpos($block['name'], 'dreisc_seo_') !== false && strpos($block['name'], '_frontend_index_header') !== false)) {
                 continue;
             }
 


### PR DESCRIPTION
The Dreischild SEO plugin has meta and title blocks that get filled with profiling information:
![image](https://user-images.githubusercontent.com/1133593/46578090-dd31d080-c9f5-11e8-963b-950b994a2b8a.png)
Although these information are useful they are cumbersome when they fill meta information with garbage that non-devs moan about that the staging site against "lost" its SEO settings.