### PR TITLE
Update Shopware version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Profiling for Shopware
 | Version 	| Requirements               	| Availability                            	|
 |---------	|----------------------------	|-----------------------------------------	|
 | 1.3     	| Min. Shopware 5.2, PHP 5.6 	| Github & Community Store                	|
-| 1.4     	| Min. Shopware 5.5, PHP 7.1 	| Github (with 5.6 Release also in Store) 	|
+| 1.4     	| Min. Shopware 5.6, PHP 7.1 	| Github (with 5.6 Release also in Store) 	|
 
 **Please create Pull Requests to the lowest version**
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Profiling for Shopware
 | Version 	| Requirements               	| Availability                            	|
 |---------	|----------------------------	|-----------------------------------------	|
 | 1.3     	| Min. Shopware 5.2, PHP 5.6 	| Github & Community Store                	|
-| 1.4     	| Min. Shopware 5.6, PHP 7.1 	| Github (with 5.6 Release also in Store) 	|
+| 1.4     	| Min. Shopware 5.6, PHP 7.2 	| Github & Community Store                	|
 
 **Please create Pull Requests to the lowest version**
 


### PR DESCRIPTION
Hi.

I tried to install the profiler:
```
git clone --branch 1.4.2 https://github.com/FriendsOfShopware/FroshProfiler custom/plugins/FroshProfiler
bin/console sw:plugin:refresh
bin/console sw:plugin:install FroshProfiler
```
but it errors out:
```
Das Plugin benötigt mindestens Shopware Version 5.6.0
```
I am on Shopware 5.5.3 currently.
 