### PR TITLE
Avoid TypeError calling `className` on `null`

### DIFF
--- a/Resources/views/frontend/profiler/_resources/js/app.js
+++ b/Resources/views/frontend/profiler/_resources/js/app.js
@@ -358,7 +358,8 @@ Sfjs = (function() {
 
                 for (j = 0; j < tabNavigation.length; j++) {
                     tabId = tabNavigation[j].getAttribute('data-tab-id');
-                    document.getElementById(tabId).querySelector('.tab-title').className = 'hidden';
+                    var tabTitle = document.getElementById(tabId).querySelector('.tab-title');
+                    if (tabTitle) tabTitle.className = 'hidden';
 
                     if (hasClass(tabNavigation[j], 'active')) {
                         document.getElementById(tabId).className = 'block';


### PR DESCRIPTION
Not a big deal, but I just noticed this error when switching tabs in the profiler.

It seems the `createTabs` function is called twice for whatever reason, and after it did its work (changing the element with matching `.tab-title` to only have class `hidden`) once it does not work a second time of course.

Maybe the `hidden` should only be added, not replace the `tab-title` class completely?