### PR TITLE
Cast `xdebugDepth` to `string` when doing `ini_set`

### DIFF
--- a/Components/Event/EventManager.php
+++ b/Components/Event/EventManager.php
@@ -267,7 +267,7 @@ class EventManager extends ContainerAwareEventManager
     {
         $value = Debug::dump($argument, 2, true, false);
         if ($this->xdebugInstalled) {
-            ini_set('xdebug.var_display_max_depth', $this->xdebugDepth);
+            ini_set('xdebug.var_display_max_depth', (string) $this->xdebugDepth);
         }
 
         return $value;


### PR DESCRIPTION
Fix error `PHP message: PHP Fatal error:  Uncaught TypeError: ini_set() expects parameter 2 to be string, integer given`