### PR TITLE
Add smarty_resource.php to avoid E_WARNING in Smarty.class.php

### DIFF
--- a/Components/Smarty/sysplugins/smarty_resource.php
+++ b/Components/Smarty/sysplugins/smarty_resource.php
@@ -1,0 +1,3 @@
+<?php
+
+include_once Shopware()->DocPath() . 'engine/Library/Smarty/sysplugins/smarty_resource.php';


### PR DESCRIPTION
If smarty_resource.php doesn't exist then [this include](https://github.com/shopware/shopware/blob/5.7/engine/Library/Smarty/Smarty.class.php#L89) can cause an exception. The include is probably unnecessary because the original smarty_resource.php has likely already been autoloaded, but as it's include_once it also doesn't hurt.