### PR TITLE
Only set X-Profiler header if CSRF header would also be set

### DIFF
--- a/Resources/views/@Toolbar/index.tpl
+++ b/Resources/views/@Toolbar/index.tpl
@@ -39,8 +39,13 @@
         if (window.CSRF) {
             var ajaxBeforeSend = window.CSRF._ajaxBeforeSend;
 
-            window.CSRF._ajaxBeforeSend = function (event, request) {
+            window.CSRF._ajaxBeforeSend = function (event, request, settings) {
                 ajaxBeforeSend.apply(window.CSRF, arguments);
+
+                if (Object.prototype.hasOwnProperty.call(settings, 'ignoreCSRFHeader') || settings.ignoreCSRFHeader === true || !window.CSRF.isLocalLink(settings.url)) {
+                    return;
+                }
+
                 request.setRequestHeader('X-Profiler', '{$sProfilerID}');
             };
         }


### PR DESCRIPTION
On cross origin requests the X-Profiler header can cause problems, if Access-Control-Allow-Headers is used by the server. This solution is adapted from the [CSRF protection](https://github.com/shopware/shopware/blob/5.7/themes/Frontend/Responsive/frontend/_public/src/js/jquery.csrf-protection.js#L160).